### PR TITLE
fix: render street map under Deno

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/deno.lock
+++ b/deno.lock
@@ -9,12 +9,14 @@
     "npm:@tanstack/react-router@1.168.18": "1.168.18_react@19.2.6_react-dom@19.2.6__react@19.2.6",
     "npm:@tanstack/react-start@1.167.32": "1.167.32_react@19.2.6_react-dom@19.2.6__react@19.2.6_vite@7.2.7__@types+node@25.6.2__picomatch@4.0.4_@types+node@25.6.2_@tanstack+react-router@1.168.18__react@19.2.6__react-dom@19.2.6___react@19.2.6",
     "npm:@testing-library/react@^16.3.2": "16.3.2_@testing-library+dom@10.4.1_@types+react@19.2.14_@types+react-dom@19.2.3__@types+react@19.2.14_react@19.2.6_react-dom@19.2.6__react@19.2.6",
+    "npm:@types/leaflet@^1.9.21": "1.9.21",
     "npm:@types/node@^25.6.2": "25.6.2",
     "npm:@types/react-dom@^19.2.3": "19.2.3_@types+react@19.2.14",
     "npm:@types/react@^19.2.14": "19.2.14",
     "npm:@vitejs/plugin-react@5.1.1": "5.1.1_vite@7.2.7__@types+node@25.6.2__picomatch@4.0.4_@babel+core@7.29.0_@types+node@25.6.2",
     "npm:autoprefixer@^10.4.27": "10.5.0_postcss@8.5.14",
     "npm:jsdom@^29.0.2": "29.1.1_css-tree@3.2.1",
+    "npm:leaflet@^1.9.4": "1.9.4",
     "npm:lefthook@^2.1.5": "2.1.6",
     "npm:mermaid@^11.14.0": "11.14.0_cytoscape@3.33.3",
     "npm:nitro@^3.0.260429-beta": "3.0.260429-beta_vite@7.2.7__@types+node@25.6.2__picomatch@4.0.4_srvx@0.11.15_crossws@0.4.5__srvx@0.11.15_db0@0.3.4_ofetch@2.0.0-alpha.3_@types+node@25.6.2",
@@ -1743,6 +1745,12 @@
         "@types/unist@3.0.3"
       ]
     },
+    "@types/leaflet@1.9.21": {
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dependencies": [
+        "@types/geojson"
+      ]
+    },
     "@types/mdast@4.0.4": {
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "dependencies": [
@@ -3021,6 +3029,9 @@
     },
     "layout-base@2.0.1": {
       "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
+    },
+    "leaflet@1.9.4": {
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "lefthook-darwin-arm64@2.1.6": {
       "integrity": "sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==",
@@ -4920,12 +4931,14 @@
         "npm:@tanstack/react-router@1.168.18",
         "npm:@tanstack/react-start@1.167.32",
         "npm:@testing-library/react@^16.3.2",
+        "npm:@types/leaflet@^1.9.21",
         "npm:@types/node@^25.6.2",
         "npm:@types/react-dom@^19.2.3",
         "npm:@types/react@^19.2.14",
         "npm:@vitejs/plugin-react@5.1.1",
         "npm:autoprefixer@^10.4.27",
         "npm:jsdom@^29.0.2",
+        "npm:leaflet@^1.9.4",
         "npm:lefthook@^2.1.5",
         "npm:mermaid@^11.14.0",
         "npm:nitro@^3.0.260429-beta",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@tanstack/react-router-devtools": "^1.166.13",
     "@testing-library/react": "^16.3.2",
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^25.6.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -28,6 +29,7 @@
     "@tanstack/react-router": "1.168.18",
     "@tanstack/react-start": "1.167.32",
     "autoprefixer": "^10.4.27",
+    "leaflet": "^1.9.4",
     "mermaid": "^11.14.0",
     "postcss": "^8.5.9",
     "react": "^19.2.5",

--- a/src/components/OpenStreetMap.tsx
+++ b/src/components/OpenStreetMap.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type { Map as LeafletMap } from "leaflet";
+
+const CHICAGO_CENTER = [41.8781, -87.6298] as const;
+const OPENSTREETMAP_TILES = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+const OPENSTREETMAP_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+interface OpenStreetMapProps {
+  center?: readonly [number, number];
+  height?: number;
+  markerLabel?: string;
+  zoom?: number;
+}
+
+export function OpenStreetMap({
+  center = CHICAGO_CENTER,
+  height = 420,
+  markerLabel = "Chicago, Illinois",
+  zoom = 11,
+}: OpenStreetMapProps) {
+  const mapElementRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [lat, lng] = center;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !mapElementRef.current) return;
+
+    let disposed = false;
+    let map: LeafletMap | null = null;
+
+    async function initializeMap() {
+      try {
+        const L = await import("leaflet");
+
+        if (disposed || !mapElementRef.current) return;
+
+        map = L.map(mapElementRef.current, {
+          scrollWheelZoom: true,
+        }).setView([lat, lng], zoom);
+
+        L.tileLayer(OPENSTREETMAP_TILES, {
+          attribution: OPENSTREETMAP_ATTRIBUTION,
+          detectRetina: true,
+          maxZoom: 19,
+        }).addTo(map);
+
+        const icon = L.divIcon({
+          className: "osm-map-marker",
+          html: "<span></span>",
+          iconAnchor: [11, 11],
+          iconSize: [22, 22],
+          popupAnchor: [0, -14],
+        });
+
+        L.marker([lat, lng], {
+          alt: markerLabel,
+          icon,
+          title: markerLabel,
+        })
+          .addTo(map)
+          .bindPopup(markerLabel);
+
+        mapRef.current = map;
+        map.whenReady(() => {
+          if (disposed || !map) return;
+          setIsReady(true);
+          requestAnimationFrame(() => map?.invalidateSize());
+        });
+      } catch (caughtError) {
+        if (!disposed) {
+          setError(
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError),
+          );
+        }
+      }
+    }
+
+    initializeMap();
+
+    return () => {
+      disposed = true;
+      map?.remove();
+      if (mapRef.current === map) {
+        mapRef.current = null;
+      }
+      setIsReady(false);
+    };
+  }, [lat, lng, markerLabel, zoom]);
+
+  const style = {
+    "--osm-map-height": `${height}px`,
+  } as CSSProperties;
+
+  return (
+    <figure className="osm-map-frame" style={style}>
+      <div className="osm-map-shell">
+        <div
+          ref={mapElementRef}
+          aria-label={`OpenStreetMap centered on ${markerLabel}`}
+          className="osm-map"
+        />
+
+        {!isReady && !error && <p className="osm-map-status">Loading map...</p>}
+
+        {error && (
+          <p className="osm-map-status" role="alert">
+            Map failed to load: {error}
+          </p>
+        )}
+      </div>
+      <figcaption>
+        OpenStreetMap view centered on {markerLabel}. Use the mouse wheel or map
+        controls to zoom.
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/OpenStreetMap.tsx
+++ b/src/components/OpenStreetMap.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import type { Map as LeafletMap } from "leaflet";
 
-const CHICAGO_CENTER = [41.8781, -87.6298] as const;
+const ALEXANDERPLATZ_CENTER = [52.5219, 13.4132] as const;
 const OPENSTREETMAP_TILES = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
 const OPENSTREETMAP_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
@@ -15,9 +15,9 @@ interface OpenStreetMapProps {
 }
 
 export function OpenStreetMap({
-  center = CHICAGO_CENTER,
+  center = ALEXANDERPLATZ_CENTER,
   height = 420,
-  markerLabel = "Chicago, Illinois",
+  markerLabel = "You are at Alexanderplatz, Berlin",
   zoom = 11,
 }: OpenStreetMapProps) {
   const mapElementRef = useRef<HTMLDivElement>(null);
@@ -114,10 +114,7 @@ export function OpenStreetMap({
           </p>
         )}
       </div>
-      <figcaption>
-        OpenStreetMap view centered on {markerLabel}. Use the mouse wheel or map
-        controls to zoom.
-      </figcaption>
+      <figcaption>OpenStreetMap view centered on Berlin, Germany</figcaption>
     </figure>
   );
 }

--- a/src/lib/utils/denoNodeHttp.test.ts
+++ b/src/lib/utils/denoNodeHttp.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { normalizeHeaderPairsForDenoWriteHead } from "./denoNodeHttp";
+
+describe("normalizeHeaderPairsForDenoWriteHead", () => {
+  it("flattens fetch-style header pairs for Deno's node:http writeHead", () => {
+    expect(
+      normalizeHeaderPairsForDenoWriteHead([
+        ["content-type", "text/html; charset=utf-8"],
+        ["vary", "sec-fetch-dest, accept"],
+      ]),
+    ).toEqual([
+      "content-type",
+      "text/html; charset=utf-8",
+      "vary",
+      "sec-fetch-dest, accept",
+    ]);
+  });
+
+  it("preserves already-flat raw headers", () => {
+    const headers = ["content-type", "text/html", "vary", "accept"];
+
+    expect(normalizeHeaderPairsForDenoWriteHead(headers)).toBe(headers);
+  });
+
+  it("expands array-valued headers as repeated header names", () => {
+    expect(
+      normalizeHeaderPairsForDenoWriteHead([
+        ["set-cookie", ["a=1", "b=2"]],
+        ["content-type", "text/plain"],
+      ]),
+    ).toEqual([
+      "set-cookie",
+      "a=1",
+      "set-cookie",
+      "b=2",
+      "content-type",
+      "text/plain",
+    ]);
+  });
+});

--- a/src/lib/utils/denoNodeHttp.ts
+++ b/src/lib/utils/denoNodeHttp.ts
@@ -1,0 +1,61 @@
+import { ServerResponse } from "node:http";
+
+const WRITE_HEAD_PATCH = Symbol.for("wcygan.deno-write-head-header-pairs");
+
+type PatchedServerResponsePrototype = ServerResponse & {
+  [WRITE_HEAD_PATCH]?: boolean;
+};
+
+type WriteHead = (this: ServerResponse, ...args: unknown[]) => ServerResponse;
+
+export function normalizeHeaderPairsForDenoWriteHead(
+  headers: unknown,
+): unknown {
+  if (!Array.isArray(headers)) return headers;
+
+  const isHeaderPairList = headers.every(
+    (entry) => Array.isArray(entry) && entry.length >= 2,
+  );
+  if (!isHeaderPairList) return headers;
+
+  return headers.flatMap(([name, value]) => {
+    if (Array.isArray(value)) {
+      return value.flatMap((item) => [String(name), String(item)]);
+    }
+
+    return [String(name), String(value)];
+  });
+}
+
+export function installDenoWriteHeadHeaderPairsPatch(): void {
+  if (!("Deno" in globalThis)) return;
+
+  const prototype = ServerResponse.prototype as PatchedServerResponsePrototype;
+  if (prototype[WRITE_HEAD_PATCH]) return;
+
+  const writeHead = prototype.writeHead as WriteHead;
+
+  prototype.writeHead = function patchedWriteHead(
+    this: ServerResponse,
+    statusCode: number,
+    statusMessageOrHeaders?: string | unknown,
+    headers?: unknown,
+  ) {
+    if (Array.isArray(statusMessageOrHeaders)) {
+      return writeHead.call(
+        this,
+        statusCode,
+        normalizeHeaderPairsForDenoWriteHead(statusMessageOrHeaders),
+      );
+    }
+
+    return writeHead.call(
+      this,
+      statusCode,
+      statusMessageOrHeaders as string | undefined,
+      normalizeHeaderPairsForDenoWriteHead(headers),
+    );
+  } as typeof prototype.writeHead;
+
+  prototype[WRITE_HEAD_PATCH] = true;
+}

--- a/src/posts/street-maps.mdx
+++ b/src/posts/street-maps.mdx
@@ -1,0 +1,223 @@
+---
+title: Street Maps
+date: May 15, 2026
+description: Adding an OpenStreetMap view to a static blog post
+tags: [OpenStreetMap, Leaflet, Maps]
+---
+
+import { OpenStreetMap } from "~/components/OpenStreetMap";
+
+<OpenStreetMap />
+
+This post embeds a small OpenStreetMap view centered on Chicago, Illinois. The
+map is initialized only in the browser so the static build and server-rendered
+HTML do not touch Leaflet's DOM APIs.
+
+## Code
+
+The site uses Leaflet directly. These are the dependency entries:
+
+```json
+{
+  "devDependencies": {
+    "@types/leaflet": "^1.9.21"
+  },
+  "dependencies": {
+    "leaflet": "^1.9.4"
+  }
+}
+```
+
+Leaflet's stylesheet is imported once in `src/styles/app.css`:
+
+```css
+@import "leaflet/dist/leaflet.css";
+```
+
+The same file also has the small amount of site-specific map styling:
+
+```css
+.osm-map-frame {
+  margin: 0 0 30px;
+}
+
+.osm-map-shell {
+  position: relative;
+  border: 1px solid rgb(222, 222, 222);
+  background: rgb(249, 249, 249);
+}
+
+.osm-map {
+  width: 100%;
+  height: var(--osm-map-height, 420px);
+  min-height: 320px;
+}
+
+.osm-map-status {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  background: rgba(249, 249, 249, 0.92);
+  color: rgb(102, 102, 102);
+  font-size: 15px;
+  line-height: 1.4;
+  text-align: center;
+  z-index: 500;
+}
+
+.osm-map-marker {
+  background: transparent;
+  border: 0;
+}
+
+.osm-map-marker span {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border: 3px solid rgb(255, 255, 255);
+  border-radius: 999px;
+  background: rgb(70, 110, 170);
+  box-shadow:
+    0 0 0 2px rgba(30, 70, 140, 0.45),
+    0 2px 8px rgba(0, 0, 0, 0.25);
+}
+```
+
+The reusable component lives in `src/components/OpenStreetMap.tsx`:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import type { CSSProperties } from "react";
+import type { Map as LeafletMap } from "leaflet";
+
+const CHICAGO_CENTER = [41.8781, -87.6298] as const;
+const OPENSTREETMAP_TILES = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
+const OPENSTREETMAP_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+interface OpenStreetMapProps {
+  center?: readonly [number, number];
+  height?: number;
+  markerLabel?: string;
+  zoom?: number;
+}
+
+export function OpenStreetMap({
+  center = CHICAGO_CENTER,
+  height = 420,
+  markerLabel = "Chicago, Illinois",
+  zoom = 11,
+}: OpenStreetMapProps) {
+  const mapElementRef = useRef<HTMLDivElement>(null);
+  const mapRef = useRef<LeafletMap | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+  const [lat, lng] = center;
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !mapElementRef.current) return;
+
+    let disposed = false;
+    let map: LeafletMap | null = null;
+
+    async function initializeMap() {
+      try {
+        const L = await import("leaflet");
+
+        if (disposed || !mapElementRef.current) return;
+
+        map = L.map(mapElementRef.current, {
+          scrollWheelZoom: true,
+        }).setView([lat, lng], zoom);
+
+        L.tileLayer(OPENSTREETMAP_TILES, {
+          attribution: OPENSTREETMAP_ATTRIBUTION,
+          detectRetina: true,
+          maxZoom: 19,
+        }).addTo(map);
+
+        const icon = L.divIcon({
+          className: "osm-map-marker",
+          html: "<span></span>",
+          iconAnchor: [11, 11],
+          iconSize: [22, 22],
+          popupAnchor: [0, -14],
+        });
+
+        L.marker([lat, lng], {
+          alt: markerLabel,
+          icon,
+          title: markerLabel,
+        })
+          .addTo(map)
+          .bindPopup(markerLabel);
+
+        mapRef.current = map;
+        map.whenReady(() => {
+          if (disposed || !map) return;
+          setIsReady(true);
+          requestAnimationFrame(() => map?.invalidateSize());
+        });
+      } catch (caughtError) {
+        if (!disposed) {
+          setError(
+            caughtError instanceof Error
+              ? caughtError.message
+              : String(caughtError),
+          );
+        }
+      }
+    }
+
+    initializeMap();
+
+    return () => {
+      disposed = true;
+      map?.remove();
+      if (mapRef.current === map) {
+        mapRef.current = null;
+      }
+      setIsReady(false);
+    };
+  }, [lat, lng, markerLabel, zoom]);
+
+  const style = {
+    "--osm-map-height": `${height}px`,
+  } as CSSProperties;
+
+  return (
+    <figure className="osm-map-frame" style={style}>
+      <div className="osm-map-shell">
+        <div
+          ref={mapElementRef}
+          aria-label={`OpenStreetMap centered on ${markerLabel}`}
+          className="osm-map"
+        />
+
+        {!isReady && !error && <p className="osm-map-status">Loading map...</p>}
+
+        {error && (
+          <p className="osm-map-status" role="alert">
+            Map failed to load: {error}
+          </p>
+        )}
+      </div>
+      <figcaption>
+        OpenStreetMap view centered on {markerLabel}. Use the mouse wheel or map
+        controls to zoom.
+      </figcaption>
+    </figure>
+  );
+}
+```
+
+The post imports and renders that component at the top:
+
+```mdx
+import { OpenStreetMap } from "~/components/OpenStreetMap";
+
+<OpenStreetMap />
+```

--- a/src/posts/street-maps.mdx
+++ b/src/posts/street-maps.mdx
@@ -170,5 +170,4 @@ import { OpenStreetMap } from "~/components/OpenStreetMap";
 ## References
 
 - [Leaflet](https://leafletjs.com/) for the interactive map.
-- [React](https://react.dev/) for the component model.
 - [OpenStreetMap](https://www.openstreetmap.org/) for the map tiles and source map.

--- a/src/posts/street-maps.mdx
+++ b/src/posts/street-maps.mdx
@@ -166,3 +166,9 @@ import { OpenStreetMap } from "~/components/OpenStreetMap";
 
 <OpenStreetMap />
 ```
+
+## References
+
+- [Leaflet](https://leafletjs.com/) for the interactive map.
+- [React](https://react.dev/) for the component model.
+- [OpenStreetMap](https://www.openstreetmap.org/) for the map tiles and source map.

--- a/src/posts/street-maps.mdx
+++ b/src/posts/street-maps.mdx
@@ -9,9 +9,9 @@ import { OpenStreetMap } from "~/components/OpenStreetMap";
 
 <OpenStreetMap />
 
-This post embeds a small OpenStreetMap view centered on Chicago, Illinois. The
-map is initialized only in the browser so the static build and server-rendered
-HTML do not touch Leaflet's DOM APIs.
+This post embeds a small OpenStreetMap view centered on Alexanderplatz in
+Berlin. The map is initialized only in the browser so the static build and
+server-rendered HTML do not touch Leaflet's DOM APIs.
 
 ## Code
 
@@ -34,58 +34,6 @@ Leaflet's stylesheet is imported once in `src/styles/app.css`:
 @import "leaflet/dist/leaflet.css";
 ```
 
-The same file also has the small amount of site-specific map styling:
-
-```css
-.osm-map-frame {
-  margin: 0 0 30px;
-}
-
-.osm-map-shell {
-  position: relative;
-  border: 1px solid rgb(222, 222, 222);
-  background: rgb(249, 249, 249);
-}
-
-.osm-map {
-  width: 100%;
-  height: var(--osm-map-height, 420px);
-  min-height: 320px;
-}
-
-.osm-map-status {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0;
-  background: rgba(249, 249, 249, 0.92);
-  color: rgb(102, 102, 102);
-  font-size: 15px;
-  line-height: 1.4;
-  text-align: center;
-  z-index: 500;
-}
-
-.osm-map-marker {
-  background: transparent;
-  border: 0;
-}
-
-.osm-map-marker span {
-  display: block;
-  width: 18px;
-  height: 18px;
-  border: 3px solid rgb(255, 255, 255);
-  border-radius: 999px;
-  background: rgb(70, 110, 170);
-  box-shadow:
-    0 0 0 2px rgba(30, 70, 140, 0.45),
-    0 2px 8px rgba(0, 0, 0, 0.25);
-}
-```
-
 The reusable component lives in `src/components/OpenStreetMap.tsx`:
 
 ```tsx
@@ -93,7 +41,7 @@ import { useEffect, useRef, useState } from "react";
 import type { CSSProperties } from "react";
 import type { Map as LeafletMap } from "leaflet";
 
-const CHICAGO_CENTER = [41.8781, -87.6298] as const;
+const ALEXANDERPLATZ_CENTER = [52.5219, 13.4132] as const;
 const OPENSTREETMAP_TILES = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
 const OPENSTREETMAP_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
@@ -106,9 +54,9 @@ interface OpenStreetMapProps {
 }
 
 export function OpenStreetMap({
-  center = CHICAGO_CENTER,
+  center = ALEXANDERPLATZ_CENTER,
   height = 420,
-  markerLabel = "Chicago, Illinois",
+  markerLabel = "You are at Alexanderplatz, Berlin",
   zoom = 11,
 }: OpenStreetMapProps) {
   const mapElementRef = useRef<HTMLDivElement>(null);
@@ -205,10 +153,7 @@ export function OpenStreetMap({
           </p>
         )}
       </div>
-      <figcaption>
-        OpenStreetMap view centered on {markerLabel}. Use the mouse wheel or map
-        controls to zoom.
-      </figcaption>
+      <figcaption>OpenStreetMap view centered on Berlin, Germany</figcaption>
     </figure>
   );
 }

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,6 +1,7 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+@import "leaflet/dist/leaflet.css";
 
 /* Design System - Light Theme inspired by modern minimal design */
 @layer base {
@@ -435,6 +436,64 @@
       249
     ) !important; /* Light background instead of dark */
     border: 1px solid rgb(222, 222, 222) !important; /* Light border */
+  }
+
+  .osm-map-frame {
+    margin: 0 0 30px;
+  }
+
+  .osm-map-shell {
+    position: relative;
+    border: 1px solid rgb(222, 222, 222);
+    background: rgb(249, 249, 249);
+  }
+
+  .osm-map {
+    width: 100%;
+    height: var(--osm-map-height, 420px);
+    min-height: 320px;
+  }
+
+  .osm-map-status {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    background: rgba(249, 249, 249, 0.92);
+    color: rgb(102, 102, 102);
+    font-size: 15px;
+    line-height: 1.4;
+    text-align: center;
+    z-index: 500;
+  }
+
+  .osm-map .leaflet-control-attribution {
+    font-size: 11px;
+  }
+
+  .osm-map .leaflet-control-zoom a {
+    color: rgb(30, 70, 140);
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .osm-map-marker {
+    background: transparent;
+    border: 0;
+  }
+
+  .osm-map-marker span {
+    display: block;
+    width: 18px;
+    height: 18px;
+    border: 3px solid rgb(255, 255, 255);
+    border-radius: 999px;
+    background: rgb(70, 110, 170);
+    box-shadow:
+      0 0 0 2px rgba(30, 70, 140, 0.45),
+      0 2px 8px rgba(0, 0, 0, 0.25);
   }
 
   /* Reset site typography inside Mermaid's foreignObject labels so they

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ import remarkGfm from "remark-gfm";
 import rehypeShiki from "@shikijs/rehype";
 import { addCopyButton } from "shiki-transformer-copy-button";
 import { siteMetadataPlugin } from "./scripts/site-metadata-plugin";
+import { installDenoWriteHeadHeaderPairsPatch } from "./src/lib/utils/denoNodeHttp";
+
+installDenoWriteHeadHeaderPairsPatch();
 
 export default defineConfig({
   server: {
@@ -33,6 +36,7 @@ export default defineConfig({
               "json",
               "bash",
               "markdown",
+              "mdx",
               "html",
               "css",
               "rust",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
             langs: [
               "javascript",
               "typescript",
+              "tsx",
               "json",
               "bash",
               "markdown",


### PR DESCRIPTION
## Summary

Adds the Street Maps post and fixes the Deno dev/build runtime error that prevented the route from rendering under TanStack Start + Nitro.

## Changes

- Add the OpenStreetMap/Leaflet blog post route content and reusable map component.
- Center the map and post copy on Alexanderplatz, Berlin.
- Add a Deno-only `ServerResponse.writeHead()` compatibility shim for srvx/Nitro header pair handling.
- Add focused unit coverage for header normalization.
- Include `mdx` in Shiki language registration for the post code block.

## Reproduction / validation

```sh
# typecheck
deno task typecheck

# run tests
deno task test

# build and prerender
deno task build

# run the app
deno task dev

# exercise the changed behavior
agent-browser open https://wcygan.localhost/street-maps
agent-browser wait --text "OpenStreetMap"
agent-browser get title
agent-browser snapshot -i -c
curl -k -I --max-time 10 https://wcygan.localhost/street-maps
```

Validation completed locally: typecheck passed, tests passed (21/21), build passed and prerendered `/street-maps`, `agent-browser` loaded `Street Maps - Will Cygan`, and `curl` returned HTTP 200 for the route.